### PR TITLE
chore: update repo URLs after rename to TooGoodToGo-CLI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to TGTG-CLI
+# Contributing to TooGoodToGo-CLI
 
 Thanks for your interest in contributing!
 
@@ -7,8 +7,8 @@ Thanks for your interest in contributing!
 Requires [`uv`](https://docs.astral.sh/uv/) and Python 3.12+.
 
 ```bash
-git clone https://github.com/peterschwps/TGTG-CLI.git
-cd TGTG-CLI
+git clone https://github.com/peterschwps/TooGoodToGo-CLI.git
+cd TooGoodToGo-CLI
 uv sync
 uv run pre-commit install
 uv run pre-commit install --hook-type commit-msg

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question / Discussion
-    url: https://github.com/peterschwps/TGTG-CLI/discussions/categories/q-a
+    url: https://github.com/peterschwps/TooGoodToGo-CLI/discussions/categories/q-a
     about: For usage questions or help getting started, please use Discussions.
   - name: Security Vulnerability
-    url: https://github.com/peterschwps/TGTG-CLI/security/advisories/new
+    url: https://github.com/peterschwps/TooGoodToGo-CLI/security/advisories/new
     about: Report security issues privately, not in public issues.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
 If you discover a security vulnerability, please report it
-**privately** via GitHub: <https://github.com/peterschwps/TGTG-CLI/security/advisories/new>.
+**privately** via GitHub: <https://github.com/peterschwps/TooGoodToGo-CLI/security/advisories/new>.
 
 Do not file public issues for security problems.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# TGTG-CLI
+# TooGoodToGo-CLI
 
-Unofficial command-line client for the Too Good To Go service.
+`tgtg-cli` — unofficial command-line client for the Too Good To Go service.
+
+```bash
+pip install TGTG-CLI
+```
 
 > **Disclaimer**
 >

--- a/docs/internal/INFRASTRUCTURE.md
+++ b/docs/internal/INFRASTRUCTURE.md
@@ -151,7 +151,7 @@ PEP 621 metadata. The fields PyPI consumes:
 ### `[project.urls]`
 
 Sidebar links rendered on the PyPI page. Pre-populated to point at the
-final `peterschwps/TGTG-CLI` repository.
+final `peterschwps/TooGoodToGo-CLI` repository.
 
 ### `[project.scripts]`
 
@@ -532,9 +532,9 @@ uv build
 uv run python -m twine check dist/*
 
 # Confirm CI status of latest commit
-gh run list --repo peterschwps/TGTG-CLI --limit 5
+gh run list --repo peterschwps/TooGoodToGo-CLI --limit 5
 
 # Confirm branch protection contexts
-gh api /repos/peterschwps/TGTG-CLI/branches/main/protection \
+gh api /repos/peterschwps/TooGoodToGo-CLI/branches/main/protection \
   --jq '.required_status_checks.contexts'
 ```

--- a/docs/internal/PUBLISHING_PLAN.md
+++ b/docs/internal/PUBLISHING_PLAN.md
@@ -62,7 +62,7 @@ When all of the above is done:
 
 1. **Settings → General → Danger Zone → Change repository visibility →
    Public.** GitHub will prompt twice; confirm.
-2. Refresh the local `gh` cache: `gh repo view peterschwps/TGTG-CLI
+2. Refresh the local `gh` cache: `gh repo view peterschwps/TooGoodToGo-CLI
    --json visibility`.
 
 ---
@@ -74,7 +74,7 @@ When all of the above is done:
 GitHub Free plan unlocks these only on public repositories:
 
 ```bash
-REPO=peterschwps/TGTG-CLI
+REPO=peterschwps/TooGoodToGo-CLI
 
 # Secret scanning + push protection
 gh api -X PATCH "/repos/$REPO" \
@@ -95,7 +95,7 @@ publish to real PyPI cannot slip out unattended:
 
 ```bash
 USER_ID=$(gh api /users/peterschwps --jq '.id')
-gh api -X PUT /repos/peterschwps/TGTG-CLI/environments/pypi --input - <<EOF
+gh api -X PUT /repos/peterschwps/TooGoodToGo-CLI/environments/pypi --input - <<EOF
 {
   "reviewers": [
     {"type": "User", "id": $USER_ID}
@@ -132,7 +132,7 @@ If `0.1.0` should be the first published version regardless of what
 release-please calculates:
 
 ```bash
-cd /Users/admin/Development/TGTG-CLI
+cd /Users/admin/Development/TooGoodToGo-CLI
 git checkout main
 git pull
 git tag -a v0.1.0 -m "v0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/peterschwps/TGTG-CLI"
-Repository = "https://github.com/peterschwps/TGTG-CLI"
-Issues = "https://github.com/peterschwps/TGTG-CLI/issues"
-Changelog = "https://github.com/peterschwps/TGTG-CLI/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/peterschwps/TooGoodToGo-CLI"
+Repository = "https://github.com/peterschwps/TooGoodToGo-CLI"
+Issues = "https://github.com/peterschwps/TooGoodToGo-CLI/issues"
+Changelog = "https://github.com/peterschwps/TooGoodToGo-CLI/blob/main/CHANGELOG.md"
 
 [project.scripts]
 tgtg-cli = "tgtg_cli.cli.__main__:main"


### PR DESCRIPTION
## Summary

Repo renamed from \`peterschwps/TGTG-CLI\` to \`peterschwps/TooGoodToGo-CLI\` (matches the full brand). PyPI distribution name stays \`TGTG-CLI\` — the short form is desirable for \`pip install\` and the \`tgtg-cli\` console script.

## Changes

| File | Change |
|---|---|
| \`pyproject.toml\` | \`[project.urls]\` x4 |
| \`.github/ISSUE_TEMPLATE/config.yml\` | Discussions + Security URLs |
| \`.github/SECURITY.md\` | Vulnerability reporting URL |
| \`.github/CONTRIBUTING.md\` | Title, clone URL, \`cd\` dir |
| \`README.md\` | Full brand heading + \`(tgtg-cli)\` subtitle + pip-install hint |
| \`docs/internal/INFRASTRUCTURE.md\` | Prose + gh command examples |
| \`docs/internal/PUBLISHING_PLAN.md\` | gh commands + local clone path |

## Untouched (PyPI-facing identity)

- \`pyproject.toml [project] name\`
- \`.release-please-config.json package-name\`
- \`.github/workflows/release.yml\` PyPI page URLs
- \`src/tgtg_cli/utils/version.py\` \`PACKAGE_NAME\`
- \`src/tgtg_cli/utils/logging.py\` logger name
- \`src/tgtg_cli/cli/config.py\` \`PROJECT_NAME\`
- \`tests/test_imports.py\` metadata assertion

## Type of change

- [x] chore

## Checklist

- [x] Branch named \`chore/rename-repo-urls\`
- [x] Commits follow Conventional Commits
- [x] Tests added or updated where useful (n/a)
- [x] CI will verify
- [x] CHANGELOG entry added under \`## [Unreleased]\` (n/a, internal infra)

## Follow-up (manual)

PyPI + TestPyPI Pending Publishers must be re-pointed at the new repo identifier before the next \`v*\` tag is pushed, otherwise OIDC will reject the upload.