### PR TITLE
ci: exempt bot branches from the branch-name check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
       - name: Validate branch name
         run: |
           name="${{ github.head_ref }}"
+          # Exempt automation branches whose names follow each tool's
+          # own convention (Dependabot, release-please).
+          if [[ "$name" == dependabot/* ]] \
+             || [[ "$name" == release-please--* ]]; then
+            echo "::notice::Skipping branch-name check for bot branch '$name'"
+            exit 0
+          fi
           pattern='^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)/[a-z0-9._-]+$'
           if ! echo "$name" | grep -Eq "$pattern"; then
             echo "::error::Branch '$name' must match: $pattern"


### PR DESCRIPTION
## Summary

Dependabot and release-please follow their own branch-naming conventions (\`dependabot/uv/<package>-<version>\`, \`release-please--branches--main--components--<name>\`). These do not match the project's \`<type>/<short-kebab>\` regex, so every bot PR was permanently red on the \`Branch name\` required status check.

This change adds an early-exit in the validation step for those two prefixes. Human PRs are still validated against the regex.

## After merge

Existing Dependabot PRs (#1–#4) must be rebased to pick up the updated \`ci.yml\` from main: comment \`@dependabot rebase\` on each, or close + reopen them.

## Type of change

- [x] ci

## Checklist

- [x] Branch named \`ci/exempt-bot-branches-from-name-check\`
- [x] Commits follow Conventional Commits