### PR TITLE
docs: add private vulnerability reporting to post-public steps

### DIFF
--- a/docs/internal/PUBLISHING_PLAN.md
+++ b/docs/internal/PUBLISHING_PLAN.md
@@ -85,6 +85,9 @@ gh api -X PATCH "/repos/$REPO" \
 gh api -X PATCH "/repos/$REPO/code-scanning/default-setup" \
   -f state=configured \
   -f query_suite=default
+
+# Private Vulnerability Reporting (powers the SECURITY.md link)
+gh api -X PUT "/repos/$REPO/private-vulnerability-reporting"
 ```
 
 ### 5. Add reviewer protection to the `pypi` deployment environment


### PR DESCRIPTION
## Summary

- Add \`gh api -X PUT /repos/.../private-vulnerability-reporting\` to the post-public security toggles in \`docs/internal/PUBLISHING_PLAN.md\`.
- Without this, the link in \`SECURITY.md\` returns 404 even after the repo is public.

## Test plan

- [x] Render PUBLISHING_PLAN.md, confirm new line sits next to secret-scanning + CodeQL block.