### PR TITLE
feat: add typer to create cli app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # TooGoodToGo-CLI
 
-`tgtg-cli` — unofficial command-line client for the Too Good To Go service.
+**Unofficial CLI for 'Too Good To Go' to monitor and check out items as they become available.**
 
 ```bash
 pip install TGTG-CLI
+```
+
+```bash
+tgtg              # start the interactive menu
+tgtg-cli          # alias, identical behaviour
+toogoodtogo       # alias, identical behaviour
+toogoodtogo-cli   # alias, identical behaviour
+tgtg --help
+tgtg --version
 ```
 
 > **Disclaimer**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "requests>=2.33.0",
     "rich>=14.2.0",
     "socksio>=1.0.0",
+    "typer>=0.20.0",
     "typing-extensions>=4.15.0",
 ]
 
@@ -46,7 +47,10 @@ Issues = "https://github.com/peterschwps/TooGoodToGo-CLI/issues"
 Changelog = "https://github.com/peterschwps/TooGoodToGo-CLI/blob/main/CHANGELOG.md"
 
 [project.scripts]
+tgtg = "tgtg_cli.cli.__main__:main"
 tgtg-cli = "tgtg_cli.cli.__main__:main"
+toogoodtogo = "tgtg_cli.cli.__main__:main"
+toogoodtogo-cli = "tgtg_cli.cli.__main__:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/tgtg_cli/cli/__init__.py
+++ b/src/tgtg_cli/cli/__init__.py
@@ -2,4 +2,3 @@ from tgtg_cli.cli.console import CustomizedConsole
 
 # Initialize console
 console = CustomizedConsole()
-console.clear()

--- a/src/tgtg_cli/cli/__main__.py
+++ b/src/tgtg_cli/cli/__main__.py
@@ -1,50 +1,14 @@
-import sys
-
-from tgtg_cli import config
-from tgtg_cli.cli.executor import Failure, execute_selected_method, run_safely
-from tgtg_cli.cli.menu import (
-    MenuOptions,
-    show_menu_with_selection,
-)
-from tgtg_cli.services.account_service import AccountService
-from tgtg_cli.services.product_service import ProductService
+from tgtg_cli.cli.app import app
 from tgtg_cli.utils.version import check_for_update
 
 
-def main():
+def main() -> None:
     """
-    Runs the main loop and starts the selected menu options. Checks if a newer
-    version is available before starting the loop.
+    Entry point of the program.
+    Runs the PyPI version check and starts the Typer app with the main loop.
     """
     check_for_update()
-    while True:
-        # Check if user is logged in to display corresponding menu options)
-        result = run_safely(AccountService.is_logged_in)
-        if isinstance(result, Failure):
-            sys.exit(0 if result is Failure.KEYBOARD_INTERRUPT else 1)
-        
-        # Load menu and prompt user for action
-        method_to_run = show_menu_with_selection(user_logged_in=result)
-
-        # Call selected method
-        match method_to_run:
-            case MenuOptions.Exit:
-                sys.exit(0)
-
-            case MenuOptions.Login:
-                execute_selected_method(AccountService.login)
-
-            case MenuOptions.Logout:
-                execute_selected_method(AccountService.logout)
-
-            case MenuOptions.Monitor:
-                execute_selected_method(ProductService.monitor)
-
-            case MenuOptions.Settings:
-                execute_selected_method(
-                    config.open_settings_file,
-                    exit_afterwards=True,
-                )
+    app()
 
 
 if __name__ == "__main__":

--- a/src/tgtg_cli/cli/app.py
+++ b/src/tgtg_cli/cli/app.py
@@ -1,0 +1,112 @@
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import Annotated
+
+import typer
+from typer import rich_utils
+
+from tgtg_cli import config, console
+from tgtg_cli.cli.executor import (
+    Failure,
+    execute_selected_method,
+    run_safely,
+)
+from tgtg_cli.cli.menu import MenuOptions, show_menu_with_selection
+from tgtg_cli.services.account_service import AccountService
+from tgtg_cli.services.product_service import ProductService
+from tgtg_cli.utils.version import PACKAGE_NAME
+
+# Configure styles for help output
+rich_utils.STYLE_OPTION = "bold"
+rich_utils.STYLE_SWITCH = "bold"
+rich_utils.STYLE_USAGE = "bold"
+rich_utils.STYLE_USAGE_COMMAND = "bold"
+rich_utils.STYLE_HELPTEXT_FIRST_LINE = "bold blue"
+rich_utils.STYLE_OPTIONS_PANEL_BORDER = "dim"
+
+# Create Typer app
+app = typer.Typer(
+    add_completion=False,
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+
+
+def version_callback(value: bool) -> None:
+    """
+    Prints the installed package version and exits when --version is
+    passed. Displays an error message if the version could not be retrieved.
+
+    Reference: https://typer.tiangolo.com/tutorial/options/version/.
+
+    Args:
+        value (bool): True if the --version flag was passed.
+    """
+    if not value:
+        return
+    try:
+        console.info(
+            f"\nInstalled version: {version(PACKAGE_NAME)}",
+            show_time=False,
+        )
+    except PackageNotFoundError:
+        console.error("Unable to fetch current version.")
+    finally:
+        raise typer.Exit()
+
+
+@app.command(
+    help=(
+        "Unofficial CLI for 'Too Good To Go' to monitor and check out items "
+        "as they become available."
+    ),
+)
+def main(
+    _: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            "-v",
+            callback=version_callback,
+            is_eager=True,
+            help="Show the installed version and exit.",
+        ),
+    ] = False,
+) -> None:
+    """
+    Entry callback that runs if the application is called without any
+    flags/options. Runs the main loop with the interactive menu.
+
+    Args:
+        _ (Annotated[bool, typer.Option, optional): Additional --version option
+                                                    for the application.
+    """
+    console.clear()
+    while True:
+        # Check if user is logged in to display corresponding menu options)
+        result = run_safely(AccountService.is_logged_in)
+        if isinstance(result, Failure):
+            sys.exit(0 if result is Failure.KEYBOARD_INTERRUPT else 1)
+
+        # Load menu and prompt user for action
+        method_to_run = show_menu_with_selection(user_logged_in=result)
+
+        # Call selected method
+        match method_to_run:
+            case MenuOptions.Exit:
+                sys.exit(0)
+
+            case MenuOptions.Login:
+                execute_selected_method(AccountService.login)
+
+            case MenuOptions.Logout:
+                execute_selected_method(AccountService.logout)
+
+            case MenuOptions.Monitor:
+                execute_selected_method(ProductService.monitor)
+
+            case MenuOptions.Settings:
+                execute_selected_method(
+                    config.open_settings_file,
+                    exit_afterwards=True,
+                )

--- a/src/tgtg_cli/cli/config.py
+++ b/src/tgtg_cli/cli/config.py
@@ -71,7 +71,7 @@ DEFAULT_SETTINGS: dict[str, dict[str, str]] = {
 
 def _convert_empty_string_to_none(value: object) -> object:
     """
-    Converts an empty string to None. If the value passed is not an empty 
+    Converts an empty string to None. If the value passed is not an empty
     string or of a different type, the value is returned unchanged.
 
     Args:
@@ -82,11 +82,11 @@ def _convert_empty_string_to_none(value: object) -> object:
     """
     if isinstance(value, str) and value.strip() == "":
         return None
-    return value   
+    return value
 
 class AccountSettings(BaseModel):
     email: EmailStr = Field(alias="EMAIL", min_length=5)
-    # Hint: Using float instead of Decimal because it can be serialized in 
+    # Hint: Using float instead of Decimal because it can be serialized in
     #       the JSON payloads. The precision differences are negligible.
     latitude: float = Field(alias="LATITUDE")
     longitude: float = Field(alias="LONGITUDE")
@@ -182,7 +182,7 @@ class AccountSettings(BaseModel):
                 "Invalid proxy format. "
                 "Format must be: username:password@hostname:port."
             ) from error
-            
+
         for name, part in (
             ("username", username),
             ("password", password),
@@ -446,7 +446,7 @@ class SettingsModel(BaseModel):
     def _validate_checkout_dependency(self) -> Self:
         """
         Validates the checkout dependencies. If checkout is enabled, all card
-        details must be provided. 
+        details must be provided.
 
         Raises:
             SettingsError: If checkout is enabled but card details are missing.
@@ -567,7 +567,7 @@ class Config:
         if not SETTINGS_FILE_PATH.exists():
             self.generate_new_settings_file()
 
-        # Load settings file 
+        # Load settings file
         parser = configparser.ConfigParser()
         parser.read(SETTINGS_FILE_PATH)
 
@@ -593,6 +593,7 @@ class Config:
             return SettingsModel.model_validate(settings_dict)
 
         except ValidationError as exc:
+            console.clear()
             console.error("Corrupt settings file:")
             for error in exc.errors():
                 error_type = error.get("type")
@@ -600,7 +601,7 @@ class Config:
 
                 # Show specific error message for different error types
                 if (
-                    error_type == "value_error" and 
+                    error_type == "value_error" and
                     error.get("loc") == ("ACCOUNT", "EMAIL")
                 ):
                     console.error(
@@ -764,7 +765,7 @@ class Config:
                 for key, default_value in values.items():
                     settings.set(section, key, default_value)
             settings.write(settings_file)
-        
+
         # Open settings file and exit program
         console.info(
             "New settings file generated. "

--- a/src/tgtg_cli/cli/executor.py
+++ b/src/tgtg_cli/cli/executor.py
@@ -1,5 +1,4 @@
 import sys
-import traceback
 from collections.abc import Callable
 from enum import Enum, auto
 from time import sleep
@@ -101,8 +100,8 @@ def run_safely[Value](method: Callable[[], Value]) -> Result[Value]:
         if render_exception(e):
             return Failure.KNOWN_ERROR
         else:
-            console.error(f"Unhandled exception: {str(e).rstrip('.')}.")
-            console.info(traceback.format_exc(), show_time=False)
+            console.error("\n[b]An unhandled exception occurred:[b]\n")
+            console.print_exception()
             return Failure.UNHANDLED
 
 

--- a/src/tgtg_cli/utils/version.py
+++ b/src/tgtg_cli/utils/version.py
@@ -45,12 +45,12 @@ def check_for_update() -> None:
     # Compare version and print notice if newer version available
     try:
         if parse(latest) > parse(current):
+            console.clear()
             console.warning(
                 f"New version available: {current} → {latest}.\n"
                 f"Run 'pip install --upgrade {PACKAGE_NAME}' to update."
             )
             sleep(3)
-            console.clear()
     except InvalidVersion:
         return
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -11,12 +11,17 @@ def test_package_metadata_available() -> None:
     assert metadata["Version"]
 
 
-def test_console_script_registered() -> None:
+def test_console_scripts_registered() -> None:
     """
-    The `tgtg-cli` console-script entry point must be registered.
+    All console-script entry points must be registered.
     """
     entry_points = importlib.metadata.entry_points(
         group="console_scripts"
     )
+    names = {ep.name for ep in entry_points}
 
-    assert any(ep.name == "tgtg-cli" for ep in entry_points)
+    assert "tgtg" in names
+    assert "tgtg-cli" in names
+    assert "toogoodtogo" in names
+    assert "toogoodtogo-cli" in names
+

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -166,6 +175,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -779,6 +800,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "socksio"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -814,6 +844,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "socksio" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
 
@@ -843,6 +874,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33.0" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "socksio", specifier = ">=1.0.0" },
+    { name = "typer", specifier = ">=0.20.0" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
 
@@ -879,6 +911,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
     { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
     { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- added Typer to build a CLI application
- application can now be started by only calling `tgtg` 
- more aliases are: `tgtg-cli`, `toogoodtogo` and `toogoodtogo-cli`