### PR TITLE
docs: clean up templates post-release

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,7 +57,6 @@ uv run pre-commit run --all-files   # everything pre-commit checks
 
 - Keep PRs small and focused on one change.
 - Make sure CI passes before requesting review.
-- Update `CHANGELOG.md` under `## [Unreleased]` if your change is
-  user-visible (this is automated by release-please for most cases,
-  but a manual entry helps).
+- `CHANGELOG.md` is maintained automatically by release-please from
+  the commit messages — no manual changelog edits needed.
 - Squash-merge is the only allowed merge style.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: Output of `tgtg-cli --version` (or commit hash if running from source).
+      description: Output of `tgtg --version` (or commit hash if running from source).
       placeholder: "0.1.0"
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,6 @@
 - [ ] Commits follow Conventional Commits
 - [ ] Tests added or updated where useful
 - [ ] `uv run pre-commit run --all-files` passes locally
-- [ ] CHANGELOG entry added under `## [Unreleased]` (if user-visible)
 
 ## Related issues
 


### PR DESCRIPTION
Drop stale CHANGELOG checklist items from the PR template and CONTRIBUTING — release-please maintains the changelog automatically. Switch the bug report version field to the primary `tgtg` alias.