### PR TITLE
ci: fix docs redeploy service reference

### DIFF
--- a/.github/workflows/docs-redeploy.yml
+++ b/.github/workflows/docs-redeploy.yml
@@ -27,6 +27,6 @@ jobs:
           node-version: 20
       - run: npm install -g @railway/cli
       - name: Trigger redeploy
-        run: railway redeploy --service toogoodtogo-cli-docs --yes
+        run: railway redeploy --service "${{ vars.RAILWAY_DOCS_SERVICE }}" --yes
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
The initial `docs-redeploy` run failed with `Service 'toogoodtogo-cli-docs' not found` — the Railway CLI resolves `--service` by the service's display name, not its internal hostname. Reference the service through a repo variable (`RAILWAY_DOCS_SERVICE`) so the workflow stays generic and the name is set in repo settings.