### PR TITLE
docs: hide table of contents on the home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 description: >-
   TooGoodToGo CLI is an unofficial command-line tool to monitor Too Good To Go
   items and automatically check them out the moment they become available.
+hide:
+  - toc
 ---
 
 # TooGoodToGo CLI


### PR DESCRIPTION
The landing page is short enough that the right-hand table of contents adds noise rather than aiding navigation. Hidden there via `hide: [toc]` page meta; every other page keeps its ToC.

Verified with a local build: the home page's secondary sidebar renders with the `hidden` attribute while `configuration`/`installation` do not.

Also serves as the first real docs push to exercise the auto-redeploy Action (after #43 is merged and `RAILWAY_DOCS_SERVICE` is set).