### PR TITLE
docs: remove dead subpath robots.txt

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://peterschwps.com/docs/tgtg/sitemap.xml


### PR DESCRIPTION
`docs/robots.txt` is published at `/docs/tgtg/robots.txt`, which crawlers never read — robots.txt is only honored at the **domain root**. The domain-root robots.txt is now served by the Caddy gateway (Personal-Website repo). Removing the dead copy.

Separate repo from the gateway change, hence its own PR.