### PR TITLE
docs: refine the llms.txt description

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,9 +44,10 @@ plugins:
   - llmstxt:
       markdown_description: >-
         The only CLI for Too Good To Go (TGTG) that automates the full checkout
-        process. It is the only Too Good To Go tool that handles the entire
-        checkout flow, including 3DS. Free, open-source, written in Python, and
-        cross-platform.
+        process, including 3DS. TooGoodToGo-CLI is a command-line bot that
+        monitors magic bags and reserves them automatically before they sell
+        out. It is easy to set up and doesn't require any extra tools. Free,
+        open-source and cross-platform.
       sections:
         Documentation:
           - "*.md"


### PR DESCRIPTION
Rewords the llmstxt plugin's markdown_description (the llms.txt summary): tighter, adds the bot / magic bags framing.