### PR TITLE
feat(docs): shadcn-style theme restyle with Geist

### DIFF
--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#000000" />
+  <path d="M9 11 L15 16 L9 21 M18 21 H23" fill="none" stroke="#ffffff" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6.5 8 L11.5 12 L6.5 16" />
+  <path d="M14 16 H18" />
+</svg>

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,124 @@
+/* Restyle of the Material theme: light only, black header, neutral zinc body,
+   Geist typography, flat bordered surfaces. */
+
+/* ---- Typography ---- */
+:root {
+  --md-text-font: "Geist";
+  --md-code-font: "Geist Mono";
+}
+
+/* ---- Colors (zinc, light only) ---- */
+[data-md-color-scheme="default"] {
+  --md-default-fg-color: hsla(240, 10%, 4%, 1);        /* zinc-950 */
+  --md-default-fg-color--light: hsla(240, 4%, 46%, 1); /* zinc-500 */
+  --md-default-fg-color--lighter: hsla(240, 5%, 65%, 1);
+  --md-default-fg-color--lightest: hsla(240, 6%, 90%, 1); /* borders */
+  --md-default-bg-color: #ffffff;
+
+  --md-accent-fg-color: hsla(240, 6%, 10%, 1);
+  --md-typeset-a-color: hsla(240, 6%, 10%, 1);
+
+  --md-code-fg-color: hsla(240, 6%, 10%, 1);
+  --md-code-bg-color: hsla(240, 5%, 96%, 1); /* zinc-100 */
+}
+
+/* ---- Header + drawer: flat, pure black ---- */
+/* Set both explicitly so the header and the mobile drawer share the exact same
+   black (Material applies its own near-black to each separately). */
+[data-md-color-primary="black"] .md-header,
+[data-md-color-primary="black"] .md-nav--primary .md-nav__title[for="__drawer"],
+[data-md-color-primary="black"] .md-nav__source {
+  background-color: #000 !important;
+}
+.md-header,
+.md-header--shadow {
+  box-shadow: none;
+}
+
+/* ---- Footer: hidden (copyright, generator notice, social) ---- */
+.md-footer {
+  display: none;
+}
+
+/* ---- Headings ---- */
+.md-typeset h1 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--md-default-fg-color);
+}
+.md-typeset h2,
+.md-typeset h3 {
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+/* ---- Code: rounded, bordered ---- */
+.md-typeset code {
+  border-radius: 6px;
+  padding: 0.12em 0.4em;
+  border: 1px solid var(--md-default-fg-color--lightest);
+}
+.md-typeset pre > code {
+  padding: 0.8em 1em;
+  border-radius: 10px;
+}
+
+/* ---- Search ---- */
+.md-search__form {
+  border-radius: 8px;
+}
+
+/* ---- Tables ---- */
+.md-typeset table:not([class]) {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: none;
+}
+.md-typeset table:not([class]) th {
+  background: var(--md-code-bg-color);
+  font-weight: 600;
+}
+
+/* ---- Admonitions / details: flat cards ---- */
+.md-typeset .admonition,
+.md-typeset details {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 10px;
+  box-shadow: none;
+}
+
+/* ---- Buttons ---- */
+.md-typeset .md-button {
+  border-radius: 8px;
+}
+
+/* ---- Active nav item ---- */
+.md-nav__link--active {
+  font-weight: 600;
+}
+
+/* ---- "Get started" grid cards: shadcn card look ---- */
+.md-typeset .grid.cards > ul > li {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 12px;
+  box-shadow: none;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+.md-typeset .grid.cards > ul > li:hover {
+  border-color: var(--md-default-fg-color--lighter);
+  background-color: var(--md-code-bg-color);
+}
+
+/* ---- Links: monochrome, underlined in prose ---- */
+.md-typeset a {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  text-decoration-color: var(--md-default-fg-color--lighter);
+}
+.md-typeset a:hover {
+  text-decoration-color: currentColor;
+}
+.md-typeset a:has(> img) {
+  text-decoration: none;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-title: "TooGoodToGo-CLI: Bot to Monitor & Auto-Checkout Magic Bags"
 description: >-
   The only CLI for Too Good To Go (TGTG) that automates the full checkout: it
   monitors magic bags, notifies you when they become available and pays

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,35 +11,32 @@ copyright: © Peter Schwips
 
 theme:
   name: material
+  logo: assets/logo.svg
+  favicon: assets/favicon.svg
+  font:
+    text: Geist
+    code: Geist Mono
   icon:
     repo: fontawesome/brands/github
   features:
     - navigation.instant
     - navigation.sections
     - navigation.top
-    - navigation.footer
     - search.suggest
     - search.highlight
     - content.code.copy
     - toc.follow
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: teal
-      accent: teal
-      toggle:
-        icon: material/weather-night
-        name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: teal
-      accent: teal
-      toggle:
-        icon: material/weather-sunny
-        name: Switch to light mode
+    scheme: default
+    primary: black
+    accent: grey
+
+extra_css:
+  - css/extra.css
 
 plugins:
   - search
+  - privacy
   - social
   - llmstxt:
       markdown_description: >-


### PR DESCRIPTION
## Summary

Redesign of the docs page. Uses a cleaner look to align with Shadcn components used for the homepage.

## Type of change

- [ ] feat
- [ ] fix
- [X] docs
- [X] refactor / chore
- [ ] BREAKING CHANGE

## Checklist

- [X] Branch is named `<type>/<short-kebab-description>`
- [X] Commits follow Conventional Commits
- [X] Tests added or updated where useful
- [X] `uv run pre-commit run --all-files` passes locally
