### PR TITLE
ci(docs): set DOCS_SHA before Railway redeploy

### DIFF
--- a/.github/workflows/docs-redeploy.yml
+++ b/.github/workflows/docs-redeploy.yml
@@ -26,7 +26,11 @@ jobs:
         with:
           node-version: 20
       - run: npm install -g @railway/cli
-      - name: Trigger redeploy
-        run: railway redeploy --service "${{ vars.RAILWAY_DOCS_SERVICE }}" --yes
+      - name: Bust docs clone cache and redeploy
+        run: |
+          railway variable set "DOCS_SHA=${GITHUB_SHA}" \
+            --service "${{ vars.RAILWAY_DOCS_SERVICE }}" \
+            --skip-deploys
+          railway redeploy --service "${{ vars.RAILWAY_DOCS_SERVICE }}" --yes
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
Bust the docs Docker clone cache so live picks up new commits.

## Summary

<!-- 1-3 sentences describing what this PR does and why. -->

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] BREAKING CHANGE

## Checklist

- [x] Branch is named `<type>/<short-kebab-description>`
- [x] Commits follow Conventional Commits
- [x] Tests added or updated where useful
- [x] `uv run pre-commit run --all-files` passes locally
