### PR TITLE
feat: add monitor times

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,8 @@ Behavior of the CLI when monitoring an item.
 | Key | Type | Description |
 | --- | --- | --- |
 | `DELAY_IN_MILLISECONDS` | integer | Delay between polls in milliseconds. Default: `4500`. Please note that lower delays may trigger rate limiting. |
+| `START_TIME` | time | Optional time to start the monitoring process. This time uses the 24-hour clock system ('military time') with the format HH:MM:SS. A valid time would be: 22:05:00. This time corresponds to 11:05 pm. A start time can only be used in combination with an end time! |
+| `END_TIME` | time | Optional time to stop the monitoring process. This time uses the 24-hour clock system ('military time') with the format HH:MM:SS. A valid time would be: 05:10:00. This time corresponds to 05:10 am. An end time can only be used in combination with a start time! After stopping the monitoring process the CLI will wait until the next start time and automatically start monitoring again. |
 | `NTFY_TOPIC` | string | Topic name for [Ntfy.sh](https://ntfy.sh) push notifications. Subscribe to the same topic in the ntfy app to receive alerts.<br>You can find the Ntfy setup guide [here](https://docs.ntfy.sh).<br><br>**Note:** Make sure you pick a unique string to prevent other users receiving your notifications. This could be a random [UUID](https://www.uuidgenerator.net/) or a random [password](https://1password.com/password-generator). |
 
 ### `[SOLVER]` { data-toc-label="Solver" }
@@ -110,6 +112,8 @@ CARD_SECURITY_CODE = 034
 
 [MONITOR]
 DELAY_IN_MILLISECONDS = 4500
+START_TIME = 22:05:00
+END_TIME = 05:10:00
 NTFY_TOPIC = your-unique-topic-string
 
 [SOLVER]

--- a/src/tgtg_cli/cli/config.py
+++ b/src/tgtg_cli/cli/config.py
@@ -3,7 +3,7 @@ import contextlib
 import json
 import sys
 import webbrowser
-from datetime import datetime
+from datetime import datetime, time
 from functools import cached_property
 from pathlib import Path
 from time import sleep
@@ -61,6 +61,8 @@ DEFAULT_SETTINGS: dict[str, dict[str, str]] = {
     },
     "MONITOR": {
         "DELAY_IN_MILLISECONDS": "4500",
+        "START_TIME": "",
+        "END_TIME": "",
         "NTFY_TOPIC": "",
     },
     "SOLVER": {
@@ -372,6 +374,8 @@ class PaymentSettings(BaseModel):
 
 class MonitorSettings(BaseModel):
     delay_in_milliseconds: int = Field(alias="DELAY_IN_MILLISECONDS", gt=0)
+    start_time: time | None = Field(alias="START_TIME")
+    end_time: time | None = Field(alias="END_TIME")
     ntfy_topic: str = Field(alias="NTFY_TOPIC", min_length=1)
 
     model_config = ConfigDict(populate_by_name=True)
@@ -403,6 +407,39 @@ class MonitorSettings(BaseModel):
                 sleep(4)
                 console.clear()
         return value
+
+    @field_validator("start_time", "end_time", mode="before")
+    @classmethod
+    def _convert_time_to_none_if_empty(cls, value: object) -> object:
+        """
+        Converts empty time strings to None or keeps the value unchanged.
+
+        Args:
+            value (object): Time string from the settings file.
+
+        Returns:
+            object: Converted time value or None if the value was empty.
+        """
+        return _convert_empty_string_to_none(value)
+
+    @model_validator(mode="after")
+    def _validate_time_frame(self) -> Self:
+        """
+        Validates the time frame. Ensures that start and end time are both set
+        or both empty.
+
+        Raises:
+            SettingsError: If only one of the two times is configured.
+
+        Returns:
+            Self: Validated monitor settings.
+        """
+        if (self.start_time is None) != (self.end_time is None):
+            raise SettingsError(
+                "Invalid monitor configuration. "
+                "START_TIME and END_TIME must both be set or both be empty."
+            )
+        return self
 
 
 class SolverSettings(BaseModel):
@@ -633,6 +670,11 @@ class Config:
                 elif error_type == "payment_card_number_luhn":
                     console.error(
                         f"- {path}: Card number has an invalid checksum. "
+                    )
+                elif error_type == "time_parsing":
+                    console.error(
+                        f"- {path}: Value must be a valid time in the format "
+                        f"HH:MM:SS using the 24-hour clock system."
                     )
                 else:
                     console.error(f"- {path}: {error['msg']}.")

--- a/src/tgtg_cli/services/product_service.py
+++ b/src/tgtg_cli/services/product_service.py
@@ -1,5 +1,5 @@
 import string
-from datetime import datetime
+from datetime import datetime, time, timedelta
 from time import sleep
 from typing import Any, cast, get_args
 
@@ -266,6 +266,11 @@ class ProductService:
         latitude = self._config.settings.account.latitude
         longitude = self._config.settings.account.longitude
         radius = self._config.settings.account.radius
+        checkout_enabled = self._config.settings.application.enable_checkout
+        delay = self._config.settings.monitor.delay_in_milliseconds
+        start_time = self._config.settings.monitor.start_time
+        end_time = self._config.settings.monitor.end_time
+        use_time_frame = start_time is not None and end_time is not None
 
         # Start filter configuration and item selection if no item is provided
         # (meaning it is the first time running the method)
@@ -344,40 +349,96 @@ class ProductService:
                 selected_item = items[selection - 1]
                 break
 
+        # Inner function to check if the current time is within the time frame
+        def is_within_time_frame() -> bool:
+            """
+            Checks if the current time is within the time frame.
+
+            Returns:
+                bool: True if the current time is within the time frame,
+                      otherwise False.
+            """
+            if not start_time or not end_time:
+                return True
+            current_time = datetime.now().time()
+            if start_time <= end_time:
+                return start_time <= current_time <= end_time
+            return start_time <= current_time or current_time <= end_time
+
         # Inner function for Rich's live display
-        def get_monitoring_message() -> str:
+        def get_monitoring_message(is_active: bool) -> str:
             """
             Provides the status message to be shown while monitoring an item.
+
+            Args:
+                is_active (bool): False if a monitoring time frame is used and
+                                  the current time is outside of the active
+                                  time frame, otherwise True.
 
             Returns:
                 str: Status message to be shown in the console.
             """
             item = selected_item.name
-            delay = self._config.settings.monitor.delay_in_milliseconds
+            if is_active:
+                return (
+                    f"Monitoring '{item}' to be back in stock.\n"
+                    f"➤ Delay: {delay} ms\n"
+                    f"➤ Last update: {datetime.now().strftime('%H:%M:%S')}"
+                )
+            wake_up_time = cast(time, start_time)  # only for type checking
             return (
-                f"Monitoring '{item}' to be back in stock...\n"
-                f"➤ Delay: {delay} ms\n"
-                f"➤ Last update: {datetime.now().strftime('%H:%M:%S')}"
+                f"Sleeping until {wake_up_time.strftime('%H:%M:%S')} "
+                f"before starting the monitor."
             )
+
+        # Check time frame
+        is_active = is_within_time_frame()
 
         # Loop until item is available
         console.clear()
-        with console.loading(status=get_monitoring_message()) as status:
+        status_message = get_monitoring_message(is_active)
+        with console.loading(status=status_message) as status:
             while True:
-                items_available = self._get_item_availability(
-                    latitude=latitude,
-                    longitude=longitude,
-                    item_id=selected_item.id,
-                )
-                if items_available > 0:
-                    break
-                status.update(get_monitoring_message())
-                sleep(
-                    self._config.settings.monitor.delay_in_milliseconds / 1000
-                )
+                # Check time if time frame is used
+                if use_time_frame:
+                    is_active = is_within_time_frame()
+
+                # Check if item is available
+                if is_active:
+                    items_available = self._get_item_availability(
+                        latitude=latitude,
+                        longitude=longitude,
+                        item_id=selected_item.id,
+                    )
+                    if items_available > 0:
+                        break
+
+                # Update status message and sleep
+                status.update(get_monitoring_message(is_active))
+                if is_active:
+                    sleep(delay / 1000)
+                else:
+                    current_time = datetime.now()
+
+                    # Create datetime object with current date
+                    start_dt = datetime.combine(
+                        date=current_time.date(),
+                        time=cast(time, start_time),
+                    )
+                    
+                    # Add one day if current time is past the start time
+                    # Example: Start time is 21:00:00 and end time is 22:00:00.
+                    #          Current time is 23:00:00. Then the monitor needs
+                    #          to sleep until 21:00:00 of the next day.
+                    if start_dt <= current_time:
+                        start_dt += timedelta(days=1)
+
+                    # Calculate sleep time
+                    sleep_time = (start_dt - current_time).total_seconds()
+                    sleep(sleep_time)
 
         # Stop if checkout is disabled
-        if not self._config.settings.application.enable_checkout:
+        if not checkout_enabled:
             send_notification(
                 topic=self._config.settings.monitor.ntfy_topic,
                 title="Item available!",

--- a/src/tgtg_cli/services/product_service.py
+++ b/src/tgtg_cli/services/product_service.py
@@ -425,7 +425,7 @@ class ProductService:
                         date=current_time.date(),
                         time=cast(time, start_time),
                     )
-                    
+
                     # Add one day if current time is past the start time
                     # Example: Start time is 21:00:00 and end time is 22:00:00.
                     #          Current time is 23:00:00. Then the monitor needs


### PR DESCRIPTION
## Summary

Adds START_TIME and END_TIME to the settings. Both values mark the active time frame during which the monitor runs. If the END_TIME is reached, the monitor will automatically sleep until the next START_TIME.

This is done to prevent rate limiting when running 24/7.
## Type of change

- [x] feat
- [ ] fix
- [x] docs
- [ ] refactor / chore
- [ ] BREAKING CHANGE

## Checklist

- [x] Branch is named `<type>/<short-kebab-description>`
- [x] Commits follow Conventional Commits
- [x] Tests added or updated where useful
- [x] `uv run pre-commit run --all-files` passes locally

## Related issues

Closes #56 
