### PR TITLE
feat: update endpoints

### DIFF
--- a/src/tgtg_cli/apis/tgtg.py
+++ b/src/tgtg_cli/apis/tgtg.py
@@ -17,11 +17,10 @@ from tgtg_cli.cli.types import (
     CreateOrderResult,
     DatadomeCaptchaResult,
     DatadomeCookieResult,
-    DietCategory,
+    DiscoverResult,
     Error,
-    ItemCategory,
+    FavoritesResult,
     ItemResult,
-    ItemsResult,
     OnStartupResult,
     OrdersActiveResult,
     OrderStatusResult,
@@ -30,7 +29,6 @@ from tgtg_cli.cli.types import (
     PayOrderResult,
     RefreshTokenResult,
     SignUpByEmailResult,
-    SortOption,
 )
 from tgtg_cli.utils.captcha import solve_datadome
 from tgtg_cli.utils.exceptions import (
@@ -53,8 +51,9 @@ class Endpoints:
     AUTH_BY_REQUEST_PIN = TGTG_URL + "auth/v5/authByRequestPin"
     AUTH_BY_REQUEST_POLLING_ID = TGTG_URL + "auth/v5/authByRequestPollingId"
     SIGN_UP_BY_EMAIL = TGTG_URL + "auth/v5/signUpByEmail"
-    ITEM = TGTG_URL + "item/v8/{item_id}"
-    ITEMS = TGTG_URL + "item/v8"
+    DISCOVER = TGTG_URL + "discover/v1/"
+    FAVORITES = TGTG_URL + "item/v9/favorites"
+    ITEM = TGTG_URL + "item/v9/{item_id}"
     ON_STARTUP = TGTG_URL + "app/v1/onStartup"
     ORDER_CREATE = TGTG_URL + "order/v8/create/{item_id}"
     ORDER_CANCEL = TGTG_URL + "order/v8/{order_id}/cancel"
@@ -581,110 +580,113 @@ class TGTG(BaseClient):
         )
         return response.json()
 
-    def get_items(
+    def discover(
         self,
         latitude: float,
         longitude: float,
         radius: int,
-        page_size: int = 20,
-        page: int = 1,
-        discover: bool = False,
-        favorites_only: bool = False,
-        item_categories: list[ItemCategory] | None = None,
-        diet_categories: list[DietCategory] | None = None,
-        pickup_intervals: list | None = None,
-        search_phrase: str | None = None,
-        with_stock_only: bool = False,
-        hidden_only: bool = False,
-        sort_option: SortOption = "RELEVANCE",
-        expand_radius_if_not_enough_items: bool = False,
-    ) -> ItemsResult:
+        filters: list[str] | None = None,
+    ) -> DiscoverResult:
         """
-        Retrieves items for within a given radius from a given location. Allows
-        configuration of various filters and sorting options.
+        Retrieves the discover feed for a given location. The response is a
+        list of typed buckets (item lists, quick filters, headers, actions)
+        instead of a flat item list.
 
         Args:
             latitude (float): Latitude used as search origin.
             longitude (float): Longitude used as search origin.
             radius (int): Search radius in kilometers.
-            page_size (int, optional): Number of items per page. Do NOT change
-                                       this value. As of now it doesn't seems
-                                       to work and will only lead to duplicates
-                                       or missing items in the search results.
-                                       Defaults to 20.
-            page (int, optional): Page number to request. Defaults to 1.
-            discover (bool, optional): If discover mode should be enabled.
-                                       Defaults to False.
-            favorites_only (bool, optional): If only favorites should be
-                                             returned.
-                                             Defaults to False.
-            item_categories (list[ItemCategory] | None, optional): Specific
-                                                                   item
-                                                                   categories
-                                                                   to filter
-                                                                   for.
-                                                                   Defaults to
-                                                                   None.
-            diet_categories (list[DietCategory] | None, optional): Specific
-                                                                   diet
-                                                                   categories
-                                                                   to filter
-                                                                   for.
-                                                                   Defaults to
-                                                                   None.
-            pickup_intervals (list | None, optional): Specific pickup intervals
-                                                      to filter for.
-                                                      Defaults to None.
-            search_phrase (str | None, optional): Search query to use.
+            filters (list[str] | None, optional): Quick-filter ids to apply.
                                                   Defaults to None.
-            with_stock_only (bool, optional): If only in-stock items should be
-                                              returned.
-                                              Defaults to False.
-            hidden_only (bool, optional): If only hidden items should be
-                                          returned.
-                                          Defaults to False.
-            sort_option (SortOption, optional): Sort mode for the results.
-                                                Defaults to "RELEVANCE".
-            expand_radius_if_not_enough_items (bool, optional): If the radius
-                                                                may be expanded
-                                                                by the AP if no
-                                                                items were
-                                                                found.
-                                                                Defaults to
-                                                                False.
 
         Returns:
-            ItemsResult: Paginated item search result.
+            DiscoverResult: Bucketed discover feed.
         """
-        item_categories = [] if item_categories is None else item_categories
-        diet_categories = [] if diet_categories is None else diet_categories
         data = {
             "origin": {
                 "latitude": latitude,
                 "longitude": longitude,
             },
             "radius": radius,
-            "page_size": page_size,
-            "page": page,
-            "discover": discover,
-            "favorites_only": favorites_only,
-            "item_categories": item_categories,
-            "diet_categories": diet_categories,
-            "with_stock_only": with_stock_only,
-            "hidden_only": hidden_only,
-            "sort_option": sort_option,
-            "expand_radius_if_not_enough_items": (
-                expand_radius_if_not_enough_items
-            ),
+            "supported_buckets": [
+                {
+                    "type": "ACTION",
+                    "display_types": [
+                        "RATE_ORDER",
+                        "MANUFACTURER",
+                        "STORE_REFERRAL",
+                        "DELIVERY_TAB",
+                        "LOYALTY_CARD_BANNER",
+                        "RECIPE_GENERATOR",
+                    ],
+                },
+                {
+                    "type": "HEADER",
+                    "display_types": [
+                        "SOLD_OUT",
+                        "ALMOST_SOLD_OUT",
+                        "NOTHING_NEARBY",
+                        "NOT_LIVE_HERE",
+                        "FILTERS_NO_RESULT",
+                    ],
+                },
+                {
+                    "type": "ITEM",
+                    "display_types": [
+                        "FLASH_SALES",
+                        "CATEGORY",
+                        "CLASSIC",
+                        "FAVORITES",
+                        "RECOMMENDATIONS",
+                        "MANUFACTURER",
+                        "DELIVERY_TAB",
+                    ],
+                },
+                {
+                    "type": "FILTER",
+                    "display_types": ["QUICK_FILTERS"]
+                },
+            ],
+            "experimental_group": "DEFAULT",
+            "debug_mode": False,
+            "is_gps": False,
+            "origin_updated": False,
+            "filters": filters or [],
+            "crm_campaign": {},
         }
+        response = self._post(url=Endpoints.DISCOVER, json=data)
+        return response.json()
 
-        # Add optional arguments if provided
-        if pickup_intervals:
-            data["pickup_intervals"] = pickup_intervals
-        if search_phrase:
-            data["search_phrase"] = search_phrase
+    def get_favorites(
+        self,
+        latitude: float,
+        longitude: float,
+        page: int = 0,
+        size: int = 25,
+    ) -> FavoritesResult:
+        """
+        Retrieves the user's favorite items as a paged list.
 
-        response = self._post(url=Endpoints.ITEMS, json=data)
+        Args:
+            latitude (float): Latitude used as search origin.
+            longitude (float): Longitude used as search origin.
+            page (int, optional): Zero-based page number. Defaults to 0.
+            size (int, optional): Number of items per page. Defaults to 25.
+
+        Returns:
+            FavoritesResult: Paged list of favorite items.
+        """
+        data = {
+            "origin": {
+                "latitude": latitude,
+                "longitude": longitude,
+            },
+            "paging": {
+                "page": page,
+                "size": size,
+            },
+        }
+        response = self._post(url=Endpoints.FAVORITES, json=data)
         return response.json()
 
     def create_order(self, item_id: str, count: int = 1) -> CreateOrderResult:

--- a/src/tgtg_cli/cli/types.py
+++ b/src/tgtg_cli/cli/types.py
@@ -124,6 +124,16 @@ SortOption = Literal[
     "RATING",
 ]
 
+QuickFilter = Literal[
+    "MEALS",
+    "BREAD_PASTRIES",
+    "GROCERIES",
+    "FLOWERS",
+    "PET_FOOD",
+    "VEGETARIAN",
+    "VEGAN",
+]
+
 # /auth/v5/authByEmail
 type ResponseStatusCode = int
 
@@ -163,7 +173,7 @@ class OnStartupResult(TypedDict):
     features: dict[str, Any]
 
 
-# /item/v8
+# /discover/v1/
 class AverageOverallRating(TypedDict):
     average_overall_rating: float
     rating_count: int
@@ -242,12 +252,32 @@ class Item(TypedDict):
     item_tags: list[ItemTag]
 
 
-class ItemsResult(TypedDict):
-    items: list[Item]
-    items_expanded_radius: list[Item]
+class Bucket(TypedDict):
+    bucket_type: str
+    display_type: str
+    title: NotRequired[str]
+    items: NotRequired[list[Item]]
 
 
-# /item/v8/{item_id}
+class DiscoverResult(TypedDict):
+    item_availability_status: str
+    buckets: list[Bucket]
+
+
+# /item/v9/favorites
+class Paging(TypedDict):
+    page: int
+    size: int
+    total_elements: int
+    total_pages: int
+
+
+class FavoritesResult(TypedDict):
+    favourite_items: list[Item]
+    paging: Paging
+
+
+# /item/v9/{item_id}
 class IngredientLabel(TypedDict):
     label_name: str
     probability_percentage: float

--- a/src/tgtg_cli/cli/types.py
+++ b/src/tgtg_cli/cli/types.py
@@ -117,13 +117,6 @@ ItemCategory = Literal[
     "FLOWERS_PLANTS",
 ]
 
-SortOption = Literal[
-    "RELEVANCE",
-    "DISTANCE",
-    "PRICE",
-    "RATING",
-]
-
 QuickFilter = Literal[
     "MEALS",
     "BREAD_PASTRIES",
@@ -184,24 +177,42 @@ class AverageOverallRating(TypedDict):
     average_food_quantity_rating: float
 
 
+class CategoryDetails(TypedDict):
+    id: str
+    name: str
+    icon_url_light: str
+    icon_url_dark: str
+
+
+class AllergensInfo(TypedDict):
+    shown_on_checkout: bool
+
+
 class ItemDetails(TypedDict):
     item_id: str
     item_price: Price
-    item_value: Price
+    item_value: NotRequired[Price]
+    sold_out_at_dynamic_item_price: NotRequired[Price]
     cover_picture: Picture
     logo_picture: Picture
     name: str
     description: str
     subtitle: str
-    food_handling_instructions: str
+    food_handling_instructions: NotRequired[str]
     can_user_supply_packaging: bool
     packaging_option: str
-    collection_info: str
+    collection_info: NotRequired[str]
     diet_categories: list[DietCategory]
     item_category: ItemCategory
+    item_category_v2_details: CategoryDetails
+    item_sub_category_details: CategoryDetails
     buffet: bool
     positive_rating_reasons: list[str]
     average_overall_rating: NotRequired[AverageOverallRating]
+    ratings: list[Any]
+    allergens_info: NotRequired[AllergensInfo]
+    is_edible: bool
+    is_single: bool
     favorite_count: int
 
 
@@ -213,7 +224,7 @@ class StoreLocation(TypedDict):
 class StoreDetails(TypedDict):
     store_id: str
     store_name: str
-    branch: str
+    branch: NotRequired[str]
     description: str
     tax_identifier: str
     website: str
@@ -225,13 +236,21 @@ class StoreDetails(TypedDict):
     distance: float
     cover_picture: Picture
     is_manufacturer: bool
+    is_local_hero: bool
 
 
 class ItemTag(TypedDict):
     id: str
     short_text: str
-    long_text: str
+    long_text: NotRequired[str]
+    description: NotRequired[str]
+    description_heading: NotRequired[str]
     variant: str
+
+
+class ItemCard(TypedDict):
+    item_card_type: str
+    item_card_text: str
 
 
 class Item(TypedDict):
@@ -242,6 +261,7 @@ class Item(TypedDict):
     pickup_location: PickupLocation
     purchase_end: str
     items_available: int
+    sold_out_at: NotRequired[str]
     distance: float
     favorite: bool
     subscribed_to_notification: bool
@@ -250,13 +270,29 @@ class Item(TypedDict):
     item_type: str
     matches_filters: bool
     item_tags: list[ItemTag]
+    item_card: NotRequired[ItemCard]
+
+
+class BucketFilter(TypedDict):
+    id: str
+    text: str
+    enabled: bool
+
+
+class AppliedFilters(TypedDict):
+    text: str
+    enabled_filters: list[Any]
 
 
 class Bucket(TypedDict):
     bucket_type: str
     display_type: str
+    filler_type: str
     title: NotRequired[str]
+    description: NotRequired[str]
     items: NotRequired[list[Item]]
+    filters: NotRequired[list[BucketFilter]]
+    applied_filters: NotRequired[AppliedFilters]
 
 
 class DiscoverResult(TypedDict):
@@ -296,16 +332,19 @@ class ItemResult(TypedDict):
     pickup_interval: PickupInterval
     pickup_location: PickupLocation
     purchase_end: str
+    next_sales_window_purchase_start: NotRequired[str]
     items_available: int
+    sold_out_at: NotRequired[str]
     distance: float
     favorite: bool
     subscribed_to_notification: bool
     in_sales_window: bool
     new_item: bool
     item_type: str
-    matches_filters: bool
+    matches_filters: NotRequired[bool]
     item_tags: list[ItemTag]
     item_ingredients: NotRequired[ItemIngredients]
+    sharing_url: NotRequired[str]
 
 
 # /order/v8/create/{item_id}

--- a/src/tgtg_cli/services/product_service.py
+++ b/src/tgtg_cli/services/product_service.py
@@ -1,7 +1,7 @@
 import string
 from datetime import datetime, time, timedelta
 from time import sleep
-from typing import Any, cast, get_args
+from typing import Any, cast
 
 from rich import box
 from rich.table import Table
@@ -9,8 +9,7 @@ from rich.table import Table
 from tgtg_cli.apis.tgtg import TGTG
 from tgtg_cli.cli import console
 from tgtg_cli.cli.config import Config
-from tgtg_cli.cli.menu import show_selection
-from tgtg_cli.cli.types import DietCategory, ItemCategory, SortOption
+from tgtg_cli.cli.types import Item
 from tgtg_cli.services.order_service import OrderService
 from tgtg_cli.utils.exceptions import SettingsError
 from tgtg_cli.utils.models import ItemOverview
@@ -53,18 +52,13 @@ class ProductService:
         longitude: float,
         radius: int,
         favorites_only: bool = False,
-        item_categories: list[ItemCategory] | None = None,
-        diet_categories: list[DietCategory] | None = None,
         search_phrase: str | None = None,
         sold_out_only: bool = False,
         with_stock_only: bool = False,
-        hidden_only: bool = False,
-        sort_option: SortOption = "RELEVANCE",
     ) -> list[ItemOverview]:
         """
-        Retrieves all items within a given radius from a given location. Allows
-        configuration of various filters and sorting options.
-        Iterates over all result pages and combines the items from each page.
+        Retrieves items within a given radius from a given location. Allows
+        filtering by favorites, search phrase, sold-out status and stock.
 
         Args:
             latitude (float): Latitude used as search origin.
@@ -73,21 +67,8 @@ class ProductService:
             favorites_only (bool, optional): If only favorites should be
                                              returned.
                                              Defaults to False.
-            item_categories (list[ItemCategory] | None, optional): Specific
-                                                                   item
-                                                                   categories
-                                                                   to filter
-                                                                   for.
-                                                                   Defaults to
-                                                                   None.
-            diet_categories (list[DietCategory] | None, optional): Specific
-                                                                   diet
-                                                                   categories
-                                                                   to filter
-                                                                   for.
-                                                                   Defaults to
-                                                                   None.
-            search_phrase (str | None, optional): Search query to use.
+            search_phrase (str | None, optional): Substring the display name
+                                                  must contain.
                                                   Defaults to None.
             sold_out_only (bool, optional): If only sold-out items should be
                                             returned. This can be helpful when
@@ -96,69 +77,99 @@ class ProductService:
             with_stock_only (bool, optional): If only in-stock items should be
                                               returned.
                                               Defaults to False.
-            hidden_only (bool, optional): If only hidden items should be
-                                          returned.
-                                          Defaults to False.
-            sort_option (SortOption, optional): Sort mode for the results.
-                                                Defaults to "RELEVANCE".
 
         Returns:
             list[ItemOverview]: List of all items matching the criteria.
         """
-        # IMPORTANT: keep page_size=20, changing it can lead to missing items
-        #            or duplicates!
-        all_items: list[ItemOverview] = []
-        search_args = {
-            "latitude": latitude,
-            "longitude": longitude,
-            "radius": radius,
-            "page_size": 20,  # see note above!
-            "page": 1,
-            "favorites_only": favorites_only,
-            "item_categories": item_categories,
-            "diet_categories": diet_categories,
-            "search_phrase": search_phrase,
-            "with_stock_only": with_stock_only,
-            "hidden_only": hidden_only,
-            "sort_option": sort_option,
-            "expand_radius_if_not_enough_items": False,
-        }
-        search_result = self._tgtg.get_items(**search_args)
+        # Fetch favorites only if requested
+        if favorites_only:
+            items = self._get_favorite_items(latitude, longitude)
 
-        # Combine items (if expanded radius is used items list is empty
-        # and vice versa))
-        items = search_result["items"] + search_result["items_expanded_radius"]
+        else:
+            # Fetch items from discover endpoint
+            result = self._tgtg.discover(
+                latitude=latitude,
+                longitude=longitude,
+                radius=radius,
+            )
 
-        # Iterate over all result pages
-        while len(items) != 0:
-            for item in items:
-                # Skip available items if filter_only_sold_out is True
-                if sold_out_only and item["items_available"] != 0:
+            # Flatten and de-duplicate the item buckets into a single list
+            items: list[Item] = []
+            seen: set[str] = set()
+            for bucket in result["buckets"]:
+                if bucket["bucket_type"] != "ITEM":
                     continue
+                for item in bucket.get("items", []):
+                    item_id = item["item"]["item_id"]
+                    if item_id in seen:
+                        continue
+                    seen.add(item_id)
+                    items.append(item)
 
-                # Create item overview
-                price_minor_units = item["item"]["item_price"]["minor_units"]
-                decimals = item["item"]["item_price"]["decimals"]
-                item_overview = ItemOverview(
+        # Iterate over results and apply filters
+        phrase = (search_phrase or "").casefold()
+
+        all_items: list[ItemOverview] = []
+        for item in items:
+            available = item["items_available"]
+
+            # Stock filters
+            if sold_out_only and available != 0:
+                continue
+            if with_stock_only and available == 0:
+                continue
+
+            # Search phrase
+            if phrase and phrase not in item["display_name"].casefold():
+                continue
+
+            # Create item overview
+            price_minor_units = item["item"]["item_price"]["minor_units"]
+            decimals = item["item"]["item_price"]["decimals"]
+            all_items.append(
+                ItemOverview(
                     id=item["item"]["item_id"],
                     name=item["display_name"],
                     price=round(price_minor_units / 10**decimals, 2),
                     currency_code=item["item"]["item_price"]["code"],
-                    items_available=item["items_available"],
+                    items_available=available,
                 )
-                all_items.append(item_overview)
-
-            # Fetch next page
-            search_args["page"] += 1
-            sleep(1)  # to prevent rate limiting
-            search_result = self._tgtg.get_items(**search_args)
-
-            # Update items with contents of new page
-            items = (
-                search_result["items"] + search_result["items_expanded_radius"]
             )
 
         return all_items
+
+    def _get_favorite_items(
+        self,
+        latitude: float,
+        longitude: float,
+    ) -> list[Item]:
+        """
+        Retrieves all favorite items.
+
+        Args:
+            latitude (float): Latitude used as search origin.
+            longitude (float): Longitude used as search origin.
+
+        Returns:
+            list[Item]: All favorite items across all pages.
+        """
+        items: list[Item] = []
+        page = 0
+
+        # Iterate over all pages
+        while True:
+            result = self._tgtg.get_favorites(
+                latitude=latitude,
+                longitude=longitude,
+                page=page,
+            )
+            items.extend(result["favourite_items"])
+            paging = result["paging"]
+            if page + 1 >= paging["total_pages"]:
+                break
+            page += 1
+            sleep(1)  # to prevent rate limiting
+        return items
 
     def _configure_filters(self) -> dict[str, Any]:
         """
@@ -170,43 +181,14 @@ class ProductService:
         custom_args = {}
 
         # Favorites only
-        custom_args["favorites_only"] = console.confirm_prompt.ask(
-            "Favorites only"
-        )
-
-        # Item categories
-        configure_item_categories = console.confirm_prompt.ask(
-            "\nConfigure item categories"
-        )
-        if configure_item_categories:
-            categories_available = get_args(ItemCategory)
-            selections = show_selection(
-                options=categories_available, multi_selection=True
-            )
-            custom_args["item_categories"] = [
-                categories_available[category]
-                for category in cast(list[int], selections)
-            ]
-
-        # Diet categories
-        configure_diet_categories = console.confirm_prompt.ask(
-            "\nConfigure diet categories"
-        )
-        if configure_diet_categories:
-            categories_available = get_args(DietCategory)
-            selections = show_selection(
-                options=categories_available,
-                multi_selection=True,
-            )
-            custom_args["diet_categories"] = [
-                categories_available[category]
-                for category in cast(list[int], selections)
-            ]
+        favorites_only = console.confirm_prompt.ask("Favorites only")
+        if favorites_only:
+            return {"favorites_only": True}
+        else:
+            custom_args["favorites_only"] = favorites_only
 
         # Search phrase
-        use_search_phrase = console.confirm_prompt.ask(
-            "\nUse search phrase"
-        )
+        use_search_phrase = console.confirm_prompt.ask("\nUse search phrase")
         if use_search_phrase:
             custom_args["search_phrase"] = console.prompt.ask(
                 "Search phrase"
@@ -221,23 +203,6 @@ class ProductService:
             custom_args["with_stock_only"] = console.confirm_prompt.ask(
                 "\nWith stock only"
             )
-
-        # Hidden only
-        custom_args["hidden_only"] = console.confirm_prompt.ask(
-            "\nHidden only"
-        )
-
-        # Sort option
-        configure_sort_option = console.confirm_prompt.ask(
-            "\nConfigure sort option"
-        )
-        if configure_sort_option:
-            sort_options_available = get_args(SortOption)
-            selection = show_selection(sort_options_available)
-            selection = cast(int, selection)
-            custom_args["sort_option"] = sort_options_available[selection]
-        else:
-            custom_args["sort_option"] = "RELEVANCE"
 
         return custom_args
 

--- a/uv.lock
+++ b/uv.lock
@@ -1283,7 +1283,7 @@ wheels = [
 
 [[package]]
 name = "tgtg-cli"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- updates the endpoint to search for available items (previously `item/v8/`, now `discover/v1/`)
- adds the new favorites endpoint instead of filtering `item/v8` by `favorites_only`

## Type of change

- [X] feat
- [X] fix
- [ ] docs
- [ ] refactor / chore
- [ ] BREAKING CHANGE

## Checklist

- [X] Branch is named `<type>/<short-kebab-description>`
- [X] Commits follow Conventional Commits
- [X] Tests added or updated where useful
- [X] `uv run pre-commit run --all-files` passes locally

## Related issues

Refs #59 
