### PR TITLE
feat: add internal solver for Datadome challenges

### DIFF
--- a/src/tgtg_cli/apis/tgtg.py
+++ b/src/tgtg_cli/apis/tgtg.py
@@ -40,8 +40,7 @@ from tgtg_cli.utils.exceptions import (
 from tgtg_cli.utils.models import SessionTokens
 
 TGTG_URL = "https://api.toogoodtogo.com/api/"
-DATADOME_SDK_URL = "https://api-sdk.datadome.co/sdk/"
-DATADOME_TGTG_KEY = "1D42C2CA6131C526E09F294FE96F94"
+DATADOME_SOLVER_URL = "https://peterschwps.com/api/tgtg/datadome"
 
 THREE_DS2_SDK_VERSION = "2.2.26"
 
@@ -86,10 +85,13 @@ class TGTG(BaseClient):
                 "User-Agent": self.user_agent,
                 "Accept": "application/json",
                 "Accept-Language": "en-GB",
-                "Accept-Encoding": "gzip, deflate, br",
+                "Accept-Encoding": "gzip, deflate",
             },
             proxy=self._config.settings.account.proxy,
         )
+
+        # Add datadome cookie if previously saved to file
+        self.session.cookies.update(config.load_datadome_cookie())
 
         # Add Authorization header if cached session tokens are available
         self.tokens = self._config.get_session_tokens()
@@ -304,22 +306,17 @@ class TGTG(BaseClient):
 
             # 2. Try: Requesting Datadome cookie from Datadome SDK API
             if response.status_code == 403 and request.url:
-                datadome_cookie_result = self._get_datadome_cookie(
-                    tgtg_url=request.url
-                )
+                datadome_cookie_result = self.get_datadome_cookie()
                 datadome_cookie = datadome_cookie_result.get("cookie")
                 if datadome_cookie:
-                    cookie_attributes = [
-                        value.split("=")[-1]
-                        for value in datadome_cookie.split("; ")
-                    ]
                     self.session.cookies.set(
                         name="datadome",
-                        value=str(cookie_attributes[0]),
+                        value=datadome_cookie,
                         domain=".toogoodtogo.com",
                         path="/",
                         secure=True,
                     )
+                    self._config.save_datadome_cookie(self.session.cookies)
                     self._update_prepared_request(request)
                     response = self.session.send(request)
 
@@ -350,6 +347,7 @@ class TGTG(BaseClient):
                     path="/",
                     secure=True,
                 )
+                self._config.save_datadome_cookie(self.session.cookies)
                 self._update_prepared_request(request)
                 response = self.session.send(request)
                 if response.status_code == 403:
@@ -391,35 +389,6 @@ class TGTG(BaseClient):
 
         return False, None
 
-    def _get_datadome_cookie(self, tgtg_url: str) -> DatadomeCookieResult:
-        """
-        Requests the Datadome cookie from the Datadome SDK API.
-
-        Args:
-            tgtg_url (str): URL of the TGTG API request that triggered the
-                            captcha.
-
-        Returns:
-            DatadomeCookieResult: Result of the request. Contains the status
-                                  code and the Datadome cookie if successful.
-        """
-        response = self._post(
-            url=DATADOME_SDK_URL,
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Host": "api-sdk.datadome.co",
-                "Connection": "Keep-Alive",
-                "User-Agent": "okhttp/5.1.0",
-                "Accept-Encoding": "gzip",
-            },
-            data={
-                "ddk": DATADOME_TGTG_KEY,
-                "request": tgtg_url,
-            },
-            use_session_headers=False,
-        )
-        return response.json()
-
     def _set_bearer_token(self, access_token: str) -> None:
         """
         Sets the Authorization header for the current session.
@@ -432,6 +401,17 @@ class TGTG(BaseClient):
                 "Authorization": f"Bearer {access_token}",
             }
         )
+
+    def get_datadome_cookie(self) -> DatadomeCookieResult:
+        """
+        Requests a Datadome cookie from the internal solver.
+
+        Returns:
+            DatadomeCookieResult: Result of the request. Contains the Datadome
+                                    cookie if successful.
+        """
+        response = self._get(url=DATADOME_SOLVER_URL)
+        return response.json()
 
     def refresh_tokens(self, refresh_token: str) -> RefreshTokenResult:
         """
@@ -642,10 +622,7 @@ class TGTG(BaseClient):
                         "DELIVERY_TAB",
                     ],
                 },
-                {
-                    "type": "FILTER",
-                    "display_types": ["QUICK_FILTERS"]
-                },
+                {"type": "FILTER", "display_types": ["QUICK_FILTERS"]},
             ],
             "experimental_group": "DEFAULT",
             "debug_mode": False,

--- a/src/tgtg_cli/cli/app.py
+++ b/src/tgtg_cli/cli/app.py
@@ -1,3 +1,6 @@
+import atexit
+import contextlib
+import signal
 import sys
 from importlib.metadata import PackageNotFoundError, version
 from typing import Annotated
@@ -6,6 +9,7 @@ import typer
 from requests.exceptions import ConnectionError
 from typer import rich_utils
 
+from tgtg_cli.apis.tgtg import TGTG
 from tgtg_cli.cli import console
 from tgtg_cli.cli.config import Config
 from tgtg_cli.cli.executor import (
@@ -32,6 +36,17 @@ app = typer.Typer(
     invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
+
+
+def _persist_datadome_cookie(tgtg: TGTG) -> None:
+    """
+    Persists the current Datadome cookie from the TGTG session.
+
+    Args:
+        tgtg (TGTG): TGTG client whose session cookies should be saved.
+    """
+    with contextlib.suppress(OSError):
+        Config.save_datadome_cookie(tgtg.session.cookies)
 
 
 def version_callback(value: bool) -> None:
@@ -93,14 +108,16 @@ def main(
     """
     console.clear()
 
-    # Build container and initialize Config and TGTG singletons
-    # Both providers are lazy and need to be resolved here
+    # Build container and initialize Config and TGTG singletons.
+    # Both providers are lazy and need to be resolved here.
     # Initializing the Config class checks the user's settings file for errors
-    # and loads all required variables for the application
+    # and loads all required variables for the application.
+    # Initializing the TGTG class loads the datadome cookie and session tokens
+    # if available.
     container = Container()
     try:
         container.config()
-        container.tgtg()
+        tgtg = container.tgtg()
 
     except SettingsError as e:
         console.clear()
@@ -116,6 +133,23 @@ def main(
             "Make sure you are connected to the internet."
         )
         sys.exit(1)
+
+    # Register function to persist Datadome cookie on normal exit
+    atexit.register(_persist_datadome_cookie, tgtg)
+
+    def _on_term(signum: int, frame: object) -> None:
+        """
+        Saves the Datadome cookie and exits on SIGTERM.
+
+        Args:
+            signum (int): Signal number that triggered the handler.
+            frame (object): Current stack frame when the signal was received.
+        """
+        _persist_datadome_cookie(tgtg)
+        sys.exit(128 + signum)
+
+    # Register function to persist Datadome cookie on SIGTERM
+    signal.signal(signal.SIGTERM, _on_term)
 
     # Resolve services
     account_service = container.account_service()

--- a/src/tgtg_cli/cli/config.py
+++ b/src/tgtg_cli/cli/config.py
@@ -5,6 +5,7 @@ import sys
 import webbrowser
 from datetime import datetime, time
 from functools import cached_property
+from http.cookiejar import CookieJar, LoadError, MozillaCookieJar
 from pathlib import Path
 from time import sleep
 from typing import Self
@@ -35,6 +36,7 @@ SETTINGS_FILE_PATH = SETTINGS_DIR / "settings.ini"
 CACHE_DIR = Path(user_cache_dir(PROJECT_NAME, ensure_exists=True))
 SESSION_FILE_PATH = CACHE_DIR / "session.json"
 DEVICE_FILE_PATH = CACHE_DIR / "device.json"
+COOKIES_FILE_PATH = CACHE_DIR / "cookies.txt"
 
 LOG_DIR = Path(CACHE_DIR, "logs")
 LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -85,6 +87,7 @@ def _convert_empty_string_to_none(value: object) -> object:
     if isinstance(value, str) and value.strip() == "":
         return None
     return value
+
 
 class AccountSettings(BaseModel):
     email: EmailStr = Field(alias="EMAIL", min_length=5)
@@ -827,7 +830,7 @@ class Config:
             json.dump(
                 SessionModel().model_dump(by_alias=True),
                 session_file,
-                indent=4
+                indent=4,
             )
 
     @staticmethod
@@ -871,3 +874,54 @@ class Config:
                 session_file,
                 indent=4,
             )
+
+    @staticmethod
+    def load_datadome_cookie() -> MozillaCookieJar:
+        """
+        Loads the datadome cookie from the cookies file. Creates a new empty
+        cookies file if it does not exist or is corrupt.
+
+        Returns:
+            MozillaCookieJar: Cookie jar loaded from the cookies file.
+        """
+        # Create empty CookieJar if it does not exist
+        if not COOKIES_FILE_PATH.exists():
+            Config.generate_new_cookies_file()
+            return MozillaCookieJar(filename=str(COOKIES_FILE_PATH))
+
+        # Create jar and load cookies
+        jar = MozillaCookieJar(filename=str(COOKIES_FILE_PATH))
+        try:
+            jar.load(ignore_discard=True, ignore_expires=True)
+            return jar
+
+        # Use empty jar on errors
+        except (OSError, LoadError):
+            console.warning(
+                "Invalid cookies file. Unable to load datadome cookie..."
+            )
+            Config.generate_new_cookies_file()
+            return MozillaCookieJar(filename=str(COOKIES_FILE_PATH))
+
+    @staticmethod
+    def generate_new_cookies_file() -> None:
+        """
+        Generates a new empty cookies file.
+        """
+        jar = MozillaCookieJar(filename=str(COOKIES_FILE_PATH))
+        jar.save(ignore_discard=True, ignore_expires=True)
+
+    @staticmethod
+    def save_datadome_cookie(cookies: CookieJar) -> None:
+        """
+        Saves the datadome cookie to the cookies file.
+
+        Args:
+            cookies (CookieJar): CookieJar containing the datadome cookie with
+                                 the name 'datadome'.
+        """
+        jar = MozillaCookieJar(filename=str(COOKIES_FILE_PATH))
+        for cookie in cookies:
+            if cookie.name == "datadome":
+                jar.set_cookie(cookie)
+        jar.save(ignore_discard=True, ignore_expires=True)

--- a/src/tgtg_cli/cli/types.py
+++ b/src/tgtg_cli/cli/types.py
@@ -1,7 +1,9 @@
 from typing import Any, Literal, NotRequired, Required, TypedDict
 
-# ===== Internal Types =====
 
+# ===== Internal Types =====
+class DatadomeCookieResult(TypedDict):
+    cookie: NotRequired[str]
 
 # ===== Adyen API Types =====
 # /checkoutshopper/v1/submitThreeDS2Fingerprint?token={client_key}
@@ -43,12 +45,6 @@ class BinLookupResult(TypedDict):
     brands: list[Brand]
     issuingCountryCode: str
     requestId: str
-
-
-# ===== Datadome API Types =====
-class DatadomeCookieResult(TypedDict):
-    status: int
-    cookie: NotRequired[str]
 
 
 # ===== TGTG API Types =====

--- a/src/tgtg_cli/services/product_service.py
+++ b/src/tgtg_cli/services/product_service.py
@@ -11,13 +11,12 @@ from tgtg_cli.cli import console
 from tgtg_cli.cli.config import Config
 from tgtg_cli.cli.types import Item
 from tgtg_cli.services.order_service import OrderService
-from tgtg_cli.utils.exceptions import SettingsError
+from tgtg_cli.utils.exceptions import SettingsError, UnexpectedResponse
 from tgtg_cli.utils.models import ItemOverview
 from tgtg_cli.utils.notifications import send_notification
 
 
 class ProductService:
-
     def __init__(self, config: Config, tgtg: TGTG):
         self._config = config
         self._tgtg = tgtg
@@ -190,9 +189,7 @@ class ProductService:
         # Search phrase
         use_search_phrase = console.confirm_prompt.ask("\nUse search phrase")
         if use_search_phrase:
-            custom_args["search_phrase"] = console.prompt.ask(
-                "Search phrase"
-            )
+            custom_args["search_phrase"] = console.prompt.ask("Search phrase")
 
         # Sold out only / with stock only
         sold_out_only = console.confirm_prompt.ask("\nSold out only")
@@ -227,6 +224,34 @@ class ProductService:
                            missing. This check should always be false if the
                            config validation is working as expected.
         """
+        # Fetch datadome cookie if no saved one exists, since endpoints like
+        # the item or favorites endpoint are protected
+        if not self._tgtg.session.cookies.get(name="datadome"):
+            with console.loading(
+                status=(
+                    "Solving datadome challenge. "
+                    "This might take some seconds..."
+                ),
+            ):
+                datadome_cookie_result = self._tgtg.get_datadome_cookie()
+                datadome_cookie = datadome_cookie_result.get("cookie")
+                if datadome_cookie:
+                    self._tgtg.session.cookies.set(
+                        name="datadome",
+                        value=datadome_cookie,
+                        domain=".toogoodtogo.com",
+                        path="/",
+                        secure=True,
+                    )
+                    self._config.save_datadome_cookie(
+                        cookies=self._tgtg.session.cookies
+                    )
+                else:
+                    raise UnexpectedResponse(
+                        "Failed to retrieve datadome cookie."
+                    )
+            console.clear()
+
         # Load values from config
         latitude = self._config.settings.account.latitude
         longitude = self._config.settings.account.longitude
@@ -240,7 +265,6 @@ class ProductService:
         # Start filter configuration and item selection if no item is provided
         # (meaning it is the first time running the method)
         if not selected_item:
-
             # Optional custom filters
             custom_filter = console.confirm_prompt.ask(
                 "Customize search filter"

--- a/uv.lock
+++ b/uv.lock
@@ -1283,7 +1283,7 @@ wheels = [
 
 [[package]]
 name = "tgtg-cli"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

This PR implements the internal solver API for interstitial Datadome challenges. Some endpoints like the favorites endpoints now require a valid Datadome cookie in order to access them. After generating the cookie, it gets saved to the cache. When exiting the CLI the latest datadome cookies from the session is stored in the cache and reloaded upon the next restart.

## Type of change

- [X] feat
- [X] fix
- [ ] docs
- [ ] refactor / chore
- [ ] BREAKING CHANGE

## Checklist

- [X] Branch is named `<type>/<short-kebab-description>`
- [X] Commits follow Conventional Commits
- [X] Tests added or updated where useful
- [X] `uv run pre-commit run --all-files` passes locally

## Related issues

Refs #59  